### PR TITLE
Add support for team-based ownership management

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # codeowner-gen
-I work for a company that likes to PR review everything.  I also work for a company that has a staff with an attention to well-formatted, pretty files.  If a change is made to a CODEOWNERS file that would require the file to be re-columned, then the PR would show all lines changed.  This would prompt a PR reviewer to have to either click "approve" without considering the content of the file, or actually read the entire CODEOWNERS file again.  So, I wrote codeowner-gen with this problem in mind.
+
+I work for a company that likes to PR review everything. I also work for a company that has a staff with an attention to well-formatted, pretty files. If a change is made to a CODEOWNERS file that would require the file to be re-columned, then the PR would show all lines changed. This would prompt a PR reviewer to have to either click "approve" without considering the content of the file, or actually read the entire CODEOWNERS file again. So, I wrote codeowner-gen with this problem in mind.
 
 codeowner-gen takes a well-formatted yaml file, and does a few things:
 
@@ -10,40 +11,127 @@ codeowner-gen takes a well-formatted yaml file, and does a few things:
 
 The output is then rendered to the CODEOWNERS file for you, alphabetized and/or grouped by your grouping specification, and properly columned so that the text columns align.
 
-With this workflow, a reviewer can see that the first line of the CODEOWNERS file is a codeowner-gen rendered file and ignore it, in favor of reviewing the changes in the codeowners.yaml file instead.  That file, being yaml, will show changes in a more sane and easy-to-digest format for a PR reviewer.
+With this workflow, a reviewer can see that the first line of the CODEOWNERS file is a codeowner-gen rendered file and ignore it, in favor of reviewing the changes in the codeowners.yaml file instead. That file, being yaml, will show changes in a more sane and easy-to-digest format for a PR reviewer.
 
 ## How-to install
+
 `cargo install --git https://github.com/PeterGrace/codeowner-gen.git --tag v0.2.0`
 
 ## Usage
-`codeowner-gen` in a directory with a well-formatted codeowners.yaml will output a CODEOWNERS file.  If you want to specify an alternate yaml, use `-i` option.
 
-Given a yaml file like below:
-```
+`codeowner-gen` in a directory with a well-formatted codeowners.yaml will output a CODEOWNERS file. If you want to specify an alternate yaml, use `-i` option.
+
+### Entries Format
+
+The traditional format uses an `entries` array where each entry specifies a path and its owners:
+
+```yaml
 ---
 entries:
   - path: "alpha"
     comment: "Alphabetically speaking, this probably is coming early on"
     group: "phonetic"
     owners:
-    - "@petergrace"
+      - "@petergrace"
   - path: "zebra"
     comment: "This is likely the last entry"
     group: "phonetic"
     owners:
-    - "@petergrace"
+      - "@petergrace"
   - path: "*"
     group: "main"
     owners:
-    - "@petergrace"
+      - "@petergrace"
   - path: "target/debug/deps/itoa-*"
     owners:
-    - "pete.grace@gmail.com"
-    - "@petergrace"
-    - "@petergrace/teamname"
+      - "pete.grace@gmail.com"
+      - "@petergrace"
+      - "@petergrace/teamname"
+```
+
+### Teams Format
+
+Alternatively, you can use the `teams` format which maps owners to a list of paths they own. This is useful when you want to manage ownership by team rather than by path:
+
+```yaml
+---
+teams:
+  "@petergrace":
+    - "alpha"
+    - "zebra"
+  "@myorg/platform-team":
+    - "src/"
+    - "lib/"
+  "pete.grace@gmail.com":
+    - "docs/"
+```
+
+### Teams Format with Groups
+
+Paths in the teams format can also include a `group` field. Use an object with `path` and `group` instead of a simple string:
+
+```yaml
+---
+teams:
+  "@petergrace":
+    - path: "src/"
+      group: "core"
+    - "lib/"
+  "@myorg/platform-team":
+    - path: "infra/"
+      group: "infrastructure"
+```
+
+### Mixed Format
+
+You can combine both formats. When the same path appears in both `teams` and `entries`, owners are merged and the entry's metadata (comment/group) is preserved:
+
+```yaml
+---
+teams:
+  "@myorg/team":
+    - "src/"
+entries:
+  - path: "src/"
+    comment: "Core source code"
+    owners:
+      - "@admin"
+```
+
+This results in `src/` having owners `@myorg/team @admin` with the comment "Core source code".
+
+**Note:** If the same path has a `group` defined in both `entries` and `teams`, the entry's group takes precedence. The team's group is only applied if the entry doesn't already have a group.
+
+### Example Output
+
+Given a yaml file like below:
+
+```yaml
+---
+entries:
+  - path: "alpha"
+    comment: "Alphabetically speaking, this probably is coming early on"
+    group: "phonetic"
+    owners:
+      - "@petergrace"
+  - path: "zebra"
+    comment: "This is likely the last entry"
+    group: "phonetic"
+    owners:
+      - "@petergrace"
+  - path: "*"
+    group: "main"
+    owners:
+      - "@petergrace"
+  - path: "target/debug/deps/itoa-*"
+    owners:
+      - "pete.grace@gmail.com"
+      - "@petergrace"
+      - "@petergrace/teamname"
 ```
 
 The codeowners-gen program will output:
+
 ```
 # Generated by codeowner-gen v0.1.0/2db3d0dbd7ece3182de63b440b07379cb19b49cd
 #

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 #[macro_use] extern crate tracing;
 mod structs;
+mod teams;
 
 #[cfg(test)]
 mod tests;
@@ -52,6 +53,9 @@ fn main() -> Result<()> {
         Ok(v) => v,
         Err(e) => bail!("Unable to parse config file: {:#?}", e)
     };
+
+    code_owners.entries = teams::merge_teams_into_entries(code_owners.entries, code_owners.teams);
+
     let mut longest_path = 0;
     let mut grouped = false;
     // for mvp, find longest path first...

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -1,18 +1,91 @@
-use serde::de::{Error};
-use serde::{Deserialize, Deserializer};
-use regex::Regex;
 use lazy_static::lazy_static;
+use regex::Regex;
+use serde::de::{Error, Visitor};
+use serde::{Deserialize, Deserializer};
+use std::collections::HashMap;
+use std::str::FromStr;
 
 lazy_static! {
-            static ref TEAM: Regex = Regex::new(r"^@\S+/\S+").unwrap();
-            static ref USERNAME: Regex = Regex::new(r"^@\S+").unwrap();
-            static ref EMAIL: Regex = Regex::new(r"^\S+@\S+").unwrap();
+    static ref TEAM: Regex = Regex::new(r"^@\S+/\S+").unwrap();
+    static ref USERNAME: Regex = Regex::new(r"^@\S+").unwrap();
+    static ref EMAIL: Regex = Regex::new(r"^\S+@\S+").unwrap();
 }
 
 #[derive(Deserialize, Default, Debug, PartialEq)]
 pub(crate) struct CodeOwners {
     /// a list of CodeOwner entries, that resolve to a line in CODEOWNERS file.
-    pub(crate) entries: Vec<CodeOwner>
+    #[serde(default)]
+    pub(crate) entries: Vec<CodeOwner>,
+
+    /// a mapping of owner to list of paths they own
+    #[serde(default)]
+    pub(crate) teams: HashMap<Owner, Vec<TeamPath>>,
+}
+
+#[derive(Debug, PartialEq, Clone)]
+pub(crate) struct TeamPath {
+    pub(crate) path: String,
+    pub(crate) group: Option<String>,
+}
+
+impl<'de> Deserialize<'de> for TeamPath {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct TeamPathVisitor;
+
+        impl<'de> Visitor<'de> for TeamPathVisitor {
+            type Value = TeamPath;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                formatter.write_str("a string path or an object with 'path' and optional 'group'")
+            }
+
+            fn visit_str<E>(self, value: &str) -> Result<TeamPath, E>
+            where
+                E: Error,
+            {
+                Ok(TeamPath {
+                    path: value.to_string(),
+                    group: None,
+                })
+            }
+
+            fn visit_map<M>(self, mut map: M) -> Result<TeamPath, M::Error>
+            where
+                M: serde::de::MapAccess<'de>,
+            {
+                let mut path: Option<String> = None;
+                let mut group: Option<String> = None;
+
+                while let Some(key) = map.next_key::<String>()? {
+                    match key.as_str() {
+                        "path" => {
+                            if path.is_some() {
+                                return Err(Error::duplicate_field("path"));
+                            }
+                            path = Some(map.next_value()?);
+                        }
+                        "group" => {
+                            if group.is_some() {
+                                return Err(Error::duplicate_field("group"));
+                            }
+                            group = Some(map.next_value()?);
+                        }
+                        _ => {
+                            return Err(Error::unknown_field(&key, &["path", "group"]));
+                        }
+                    }
+                }
+
+                let path = path.ok_or_else(|| Error::missing_field("path"))?;
+                Ok(TeamPath { path, group })
+            }
+        }
+
+        deserializer.deserialize_any(TeamPathVisitor)
+    }
 }
 
 #[derive(Deserialize, Default, Debug, PartialEq)]
@@ -20,34 +93,38 @@ pub(crate) struct CodeOwner {
     pub(crate) path: String,
     #[serde(deserialize_with = "owners_from_string")]
     pub(crate) owners: Vec<Owner>,
-    #[serde(skip_serializing_if="Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) comment: Option<String>,
-    #[serde(skip_serializing_if="Option::is_none")]
-    pub(crate) group: Option<String>
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) group: Option<String>,
 }
 
 fn owners_from_string<'de, D>(input: D) -> Result<Vec<Owner>, D::Error>
-where D: Deserializer<'de> {
+where
+    D: Deserializer<'de>,
+{
     let mut results: Vec<Owner> = vec![];
-    let input_strings :Vec<String> = Vec::deserialize(input)?;
-    for inpstr in input_strings {
-    for obj in inpstr.split_whitespace() {
-        if TEAM.is_match(obj) {
-            results.push(Owner::Team(obj.to_string()))
-        } else if USERNAME.is_match(obj) {
-            results.push(Owner::Username(obj.to_string()))
-        } else if EMAIL.is_match(obj) {
-            results.push(Owner::Email(obj.to_string()))
-        } else {
-            return Err(Error::custom("invalid value for owner.  Expected @username, @team/name, or email@email.com"));
-        }
+    let input_strings: Vec<String> = Vec::deserialize(input)?;
 
-    }
+    for inpstr in input_strings {
+        for obj in inpstr.split_whitespace() {
+            if TEAM.is_match(obj) {
+                results.push(Owner::Team(obj.to_string()))
+            } else if USERNAME.is_match(obj) {
+                results.push(Owner::Username(obj.to_string()))
+            } else if EMAIL.is_match(obj) {
+                results.push(Owner::Email(obj.to_string()))
+            } else {
+                return Err(Error::custom(
+                    "Invalid value for owner. Expected @username, @team/name, or email@email.com",
+                ));
+            }
+        }
     }
     Ok(results)
 }
 
-#[derive(Deserialize, Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub enum Owner {
     /// Owner in the form @username
     Username(String),
@@ -56,11 +133,54 @@ pub enum Owner {
     /// Owner in the form user@domain.com
     Email(String),
 }
+
+impl FromStr for Owner {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if TEAM.is_match(s) {
+            Ok(Owner::Team(s.to_string()))
+        } else if USERNAME.is_match(s) {
+            Ok(Owner::Username(s.to_string()))
+        } else if EMAIL.is_match(s) {
+            Ok(Owner::Email(s.to_string()))
+        } else {
+            Err("Invalid owner format. Expected @username, @org/team, or email@domain.com".into())
+        }
+    }
+}
+
 impl std::fmt::Display for Owner {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
             // v is a String in both cases
             Owner::Email(v) | Owner::Team(v) | Owner::Username(v) => v.fmt(f),
         }
+    }
+}
+
+impl<'de> Deserialize<'de> for Owner {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct OwnerVisitor;
+
+        impl<'de> Visitor<'de> for OwnerVisitor {
+            type Value = Owner;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                formatter.write_str("a string like @username, @org/team, or email@domain.com")
+            }
+
+            fn visit_str<E>(self, value: &str) -> Result<Owner, E>
+            where
+                E: Error,
+            {
+                Owner::from_str(value).map_err(Error::custom)
+            }
+        }
+
+        deserializer.deserialize_str(OwnerVisitor)
     }
 }

--- a/src/teams.rs
+++ b/src/teams.rs
@@ -1,0 +1,285 @@
+use crate::structs::{CodeOwner, Owner, TeamPath};
+use std::collections::HashMap;
+
+/// Merges teams mapping into entries, combining owners for duplicate paths.
+/// When the same path appears in both teams and entries, owners are merged
+/// and the entry's metadata (comment/group) is preserved. Groups from teams
+/// are also applied if the entry doesn't already have a group.
+pub(crate) fn merge_teams_into_entries(
+    entries: Vec<CodeOwner>,
+    teams: HashMap<Owner, Vec<TeamPath>>,
+) -> Vec<CodeOwner> {
+    let mut path_map: HashMap<String, CodeOwner> = HashMap::new();
+
+    for entry in entries {
+        path_map
+            .entry(entry.path.clone())
+            .and_modify(|existing| {
+                for owner in &entry.owners {
+                    if !existing.owners.contains(owner) {
+                        existing.owners.push(owner.clone());
+                    }
+                }
+
+                if existing.comment.is_none() && entry.comment.is_some() {
+                    existing.comment = entry.comment.clone();
+                }
+
+                if existing.group.is_none() && entry.group.is_some() {
+                    existing.group = entry.group.clone();
+                }
+            })
+            .or_insert(entry);
+    }
+
+    for (owner, team_paths) in teams {
+        for team_path in team_paths {
+            path_map
+                .entry(team_path.path.clone())
+                .and_modify(|existing| {
+                    if !existing.owners.contains(&owner) {
+                        existing.owners.push(owner.clone());
+                    }
+
+                    if existing.group.is_none() && team_path.group.is_some() {
+                        existing.group = team_path.group.clone();
+                    }
+                })
+                .or_insert_with(|| CodeOwner {
+                    path: team_path.path,
+                    owners: vec![owner.clone()],
+                    comment: None,
+                    group: team_path.group,
+                });
+        }
+    }
+
+    path_map.into_values().collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn path(s: &str) -> TeamPath {
+        TeamPath {
+            path: s.to_string(),
+            group: None,
+        }
+    }
+
+    fn path_with_group(s: &str, g: &str) -> TeamPath {
+        TeamPath {
+            path: s.to_string(),
+            group: Some(g.to_string()),
+        }
+    }
+
+    #[test]
+    fn test_merge_teams_creates_entries() {
+        let mut teams = HashMap::new();
+
+        teams.insert(
+            Owner::Username(String::from("@petergrace")),
+            vec![path("src/"), path("lib/")],
+        );
+
+        let result = merge_teams_into_entries(vec![], teams);
+
+        assert_eq!(result.len(), 2);
+
+        let paths: Vec<&str> = result.iter().map(|e| e.path.as_str()).collect();
+
+        assert!(paths.contains(&"src/"));
+        assert!(paths.contains(&"lib/"));
+    }
+
+    #[test]
+    fn test_merge_teams_combines_owners_for_same_path() {
+        let mut teams = HashMap::new();
+
+        teams.insert(
+            Owner::Username(String::from("@alice")),
+            vec![path("src/")],
+        );
+
+        teams.insert(
+            Owner::Team(String::from("@org/team")),
+            vec![path("src/")],
+        );
+
+        let result = merge_teams_into_entries(vec![], teams);
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].path, "src/");
+        assert_eq!(result[0].owners.len(), 2);
+    }
+
+    #[test]
+    fn test_merge_preserves_entry_metadata() {
+        let entries = vec![CodeOwner {
+            path: String::from("src/"),
+            owners: vec![Owner::Username(String::from("@admin"))],
+            comment: Some(String::from("Core source")),
+            group: Some(String::from("main")),
+        }];
+
+        let mut teams = HashMap::new();
+
+        teams.insert(
+            Owner::Team(String::from("@org/team")),
+            vec![path("src/")],
+        );
+
+        let result = merge_teams_into_entries(entries, teams);
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].comment, Some(String::from("Core source")));
+        assert_eq!(result[0].group, Some(String::from("main")));
+        assert_eq!(result[0].owners.len(), 2);
+    }
+
+    #[test]
+    fn test_merge_deduplicates_owners() {
+        let entries = vec![CodeOwner {
+            path: String::from("src/"),
+            owners: vec![Owner::Username(String::from("@alice"))],
+            comment: None,
+            group: None,
+        }];
+
+        let mut teams = HashMap::new();
+
+        teams.insert(
+            Owner::Username(String::from("@alice")),
+            vec![path("src/")],
+        );
+
+        let result = merge_teams_into_entries(entries, teams);
+
+        assert_eq!(result.len(), 1);
+
+        assert_eq!(result[0].owners.len(), 1);
+    }
+
+    #[test]
+    fn test_merge_teams_with_group() {
+        let mut teams = HashMap::new();
+
+        teams.insert(
+            Owner::Username(String::from("@petergrace")),
+            vec![path_with_group("src/", "core")],
+        );
+
+        let result = merge_teams_into_entries(vec![], teams);
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].path, "src/");
+        assert_eq!(result[0].group, Some(String::from("core")));
+    }
+
+    #[test]
+    fn test_entry_group_takes_precedence_over_team_group() {
+        let entries = vec![CodeOwner {
+            path: String::from("src/"),
+            owners: vec![Owner::Username(String::from("@admin"))],
+            comment: None,
+            group: Some(String::from("main")),
+        }];
+
+        let mut teams = HashMap::new();
+
+        teams.insert(
+            Owner::Team(String::from("@org/team")),
+            vec![path_with_group("src/", "core")],
+        );
+
+        let result = merge_teams_into_entries(entries, teams);
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].group, Some(String::from("main")));
+        assert_eq!(result[0].owners.len(), 2);
+    }
+
+    #[test]
+    fn test_team_group_applied_when_entry_has_none() {
+        let entries = vec![CodeOwner {
+            path: String::from("src/"),
+            owners: vec![Owner::Username(String::from("@admin"))],
+            comment: None,
+            group: None,
+        }];
+
+        let mut teams = HashMap::new();
+
+        teams.insert(
+            Owner::Team(String::from("@org/team")),
+            vec![path_with_group("src/", "core")],
+        );
+
+        let result = merge_teams_into_entries(entries, teams);
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].group, Some(String::from("core")));
+        assert_eq!(result[0].owners.len(), 2);
+    }
+
+    #[test]
+    fn test_mixed_format_with_overlapping_paths() {
+        use crate::structs::CodeOwners;
+
+        const INPUT_DATA: &str = "
+---
+teams:
+  \"@myorg/team\":
+    - \"src/\"
+entries:
+  - path: \"src/\"
+    comment: \"Core source code\"
+    group: \"core\"
+    owners:
+      - \"@admin\"
+";
+        let code_owners: CodeOwners = serde_yaml::from_str(INPUT_DATA).unwrap();
+
+        let merged = merge_teams_into_entries(code_owners.entries, code_owners.teams);
+
+        assert_eq!(merged.len(), 1);
+        assert_eq!(merged[0].path, "src/");
+        assert_eq!(merged[0].comment, Some(String::from("Core source code")));
+        assert_eq!(merged[0].group, Some(String::from("core")));
+        assert_eq!(merged[0].owners.len(), 2);
+
+        let owner_strings: Vec<String> = merged[0].owners.iter().map(|o| o.to_string()).collect();
+
+        assert!(owner_strings.contains(&String::from("@admin")));
+        assert!(owner_strings.contains(&String::from("@myorg/team")));
+    }
+
+    #[test]
+    fn test_teams_with_group_yaml_parsing() {
+        use crate::structs::CodeOwners;
+
+        const INPUT_DATA: &str = "
+---
+teams:
+  \"@petergrace\":
+    - path: \"src/\"
+      group: \"core\"
+    - \"lib/\"
+";
+        let code_owners: CodeOwners = serde_yaml::from_str(INPUT_DATA).unwrap();
+
+        let merged = merge_teams_into_entries(code_owners.entries, code_owners.teams);
+
+        assert_eq!(merged.len(), 2);
+
+        let src_entry = merged.iter().find(|e| e.path == "src/").unwrap();
+
+        assert_eq!(src_entry.group, Some(String::from("core")));
+
+        let lib_entry = merged.iter().find(|e| e.path == "lib/").unwrap();
+
+        assert_eq!(lib_entry.group, None);
+    }
+}

--- a/src/tests/serialization.rs
+++ b/src/tests/serialization.rs
@@ -1,5 +1,13 @@
-use crate::structs::{CodeOwners, CodeOwner, Owner};
+use crate::structs::{CodeOwners, CodeOwner, Owner, TeamPath};
+use std::collections::HashMap;
 use serde_yaml;
+
+fn team_path(s: &str) -> TeamPath {
+    TeamPath {
+        path: s.to_string(),
+        group: None,
+    }
+}
 
 #[test]
 fn test_single_username()
@@ -20,7 +28,8 @@ entries:
                 path: String::from("*"),
                 owners: vec![Owner::Username(String::from("@petergrace"))]
             }
-        ]
+        ],
+        teams: HashMap::new(),
     };
     assert_eq!(value, control)
 }
@@ -44,7 +53,8 @@ entries:
                 path: String::from("*"),
                 owners: vec![Owner::Team(String::from("@my/team"))]
             }
-        ]
+        ],
+        teams: HashMap::new(),
     };
     assert_eq!(value, control)
 }
@@ -68,7 +78,8 @@ entries:
                 path: String::from("*"),
                 owners: vec![Owner::Email(String::from("pete.grace@gmail.com"))]
             }
-        ]
+        ],
+        teams: HashMap::new(),
     };
     assert_eq!(value, control)
 }
@@ -110,7 +121,8 @@ entries:
                 ]
             },
 
-        ]
+        ],
+        teams: HashMap::new(),
     };
     assert_eq!(value, control)
 }
@@ -128,6 +140,7 @@ entries:
       - \"@petergrace\"
 ";
     let value = serde_yaml::from_str::<CodeOwners>(INPUT_DATA).unwrap();
+
     let control: CodeOwners = CodeOwners {
         entries: vec![
             CodeOwner{
@@ -136,7 +149,156 @@ entries:
                 path: String::from("*"),
                 owners: vec![Owner::Username(String::from("@petergrace"))]
             }
-        ]
+        ],
+        teams: HashMap::new(),
     };
+
+    assert_eq!(value, control)
+}
+
+#[test]
+fn test_teams_only()
+{
+    const INPUT_DATA: &str = "
+---
+teams:
+  \"@petergrace\":
+    - \"alpha\"
+    - \"zebra\"
+";
+    let value = serde_yaml::from_str::<CodeOwners>(INPUT_DATA).unwrap();
+    let mut expected_teams = HashMap::new();
+
+    expected_teams.insert(
+        Owner::Username(String::from("@petergrace")),
+        vec![team_path("alpha"), team_path("zebra")]
+    );
+
+    let control: CodeOwners = CodeOwners {
+        entries: vec![],
+        teams: expected_teams,
+    };
+
+    assert_eq!(value, control)
+}
+
+#[test]
+fn test_teams_with_org_team()
+{
+    const INPUT_DATA: &str = "
+---
+teams:
+  \"@myorg/team\":
+    - \"src/\"
+    - \"lib/\"
+";
+    let value = serde_yaml::from_str::<CodeOwners>(INPUT_DATA).unwrap();
+    let mut expected_teams = HashMap::new();
+
+    expected_teams.insert(
+        Owner::Team(String::from("@myorg/team")),
+        vec![team_path("src/"), team_path("lib/")]
+    );
+
+    let control: CodeOwners = CodeOwners {
+        entries: vec![],
+        teams: expected_teams,
+    };
+
+    assert_eq!(value, control)
+}
+
+#[test]
+fn test_teams_with_email()
+{
+    const INPUT_DATA: &str = "
+---
+teams:
+  \"pete.grace@gmail.com\":
+    - \"docs/\"
+";
+    let value = serde_yaml::from_str::<CodeOwners>(INPUT_DATA).unwrap();
+    let mut expected_teams = HashMap::new();
+
+    expected_teams.insert(
+        Owner::Email(String::from("pete.grace@gmail.com")),
+        vec![team_path("docs/")]
+    );
+
+    let control: CodeOwners = CodeOwners {
+        entries: vec![],
+        teams: expected_teams,
+    };
+
+    assert_eq!(value, control)
+}
+
+#[test]
+fn test_mixed_entries_and_teams()
+{
+    const INPUT_DATA: &str = "
+---
+entries:
+  - path: \"special/*\"
+    comment: \"Needs metadata\"
+    owners:
+      - \"@admin\"
+teams:
+  \"@petergrace\":
+    - \"src/\"
+";
+    let value = serde_yaml::from_str::<CodeOwners>(INPUT_DATA).unwrap();
+    let mut expected_teams = HashMap::new();
+
+    expected_teams.insert(
+        Owner::Username(String::from("@petergrace")),
+        vec![team_path("src/")]
+    );
+
+    let control: CodeOwners = CodeOwners {
+        entries: vec![
+            CodeOwner {
+                comment: Some(String::from("Needs metadata")),
+                group: None,
+                path: String::from("special/*"),
+                owners: vec![Owner::Username(String::from("@admin"))]
+            }
+        ],
+        teams: expected_teams,
+    };
+
+    assert_eq!(value, control)
+}
+
+#[test]
+fn test_invalid_owner_in_teams()
+{
+    const INPUT_DATA: &str = "
+---
+teams:
+  \"invalid-owner\":
+    - \"src/\"
+";
+    let result = serde_yaml::from_str::<CodeOwners>(INPUT_DATA);
+
+    assert!(result.is_err());
+
+    let err = result.unwrap_err().to_string();
+
+    assert!(err.contains("Invalid owner format"), "Error was: {}", err);
+}
+
+#[test]
+fn test_empty_config()
+{
+    const INPUT_DATA: &str = "---";
+
+    let value = serde_yaml::from_str::<CodeOwners>(INPUT_DATA).unwrap();
+
+    let control: CodeOwners = CodeOwners {
+        entries: vec![],
+        teams: HashMap::new(),
+    };
+
     assert_eq!(value, control)
 }


### PR DESCRIPTION
Add a new `teams` field that maps owners to lists of paths, as an alternative to the existing entries format.

The existing entries format requires listing paths with their owners, which can be repetitive when one team owns many paths. The new teams format allows defining ownership from the team's perspective:

```
teams:
  "@myorg/platform-team":
    - "src/"
    - "lib/"
    - path: "infra/"
      group: "infrastructure"
```