### PR TITLE
Add support for multi-owner teams

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,35 @@ teams:
       group: "infrastructure"
 ```
 
+### Inline Multi-Owner Teams
+
+You can specify multiple owners for the same set of paths using a YAML array as the key. This is useful when multiple teams or individuals share ownership of the same directories:
+
+```yaml
+---
+teams:
+  ["@alice", "@bob", "@myorg/platform-team"]:
+    - "src/"
+    - "lib/"
+  "@carol":
+    - "docs/"
+```
+
+This results in `src/` and `lib/` each having all three owners (`@alice`, `@bob`, and `@myorg/platform-team`), while `docs/` is owned only by `@carol`.
+
+You can also combine inline multi-owner teams with groups:
+
+```yaml
+---
+teams:
+  ["@alice", "@bob"]:
+    - path: "src/"
+      group: "core"
+    - "lib/"
+```
+
+Each owner in the array must be a valid owner format (`@username`, `@org/team`, or `email@domain.com`).
+
 ### Mixed Format
 
 You can combine both formats. When the same path appears in both `teams` and `entries`, owners are merged and the entry's metadata (comment/group) is preserved:

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -1,6 +1,6 @@
 use lazy_static::lazy_static;
 use regex::Regex;
-use serde::de::{Error, Visitor};
+use serde::de::{Error, SeqAccess, Visitor};
 use serde::{Deserialize, Deserializer};
 use std::collections::HashMap;
 use std::str::FromStr;
@@ -13,13 +13,63 @@ lazy_static! {
 
 #[derive(Deserialize, Default, Debug, PartialEq)]
 pub(crate) struct CodeOwners {
-    /// a list of CodeOwner entries, that resolve to a line in CODEOWNERS file.
+    /// A list of CodeOwner entries, that resolve to a line in CODEOWNERS file
     #[serde(default)]
     pub(crate) entries: Vec<CodeOwner>,
 
-    /// a mapping of owner to list of paths they own
+    /// A mapping of owner(s) to list of paths they own
     #[serde(default)]
-    pub(crate) teams: HashMap<Owner, Vec<TeamPath>>,
+    pub(crate) teams: HashMap<OwnerKey, Vec<TeamPath>>,
+}
+
+#[derive(Debug, PartialEq, Eq, Hash, Clone)]
+pub(crate) struct OwnerKey(pub(crate) Vec<Owner>);
+
+impl<'de> Deserialize<'de> for OwnerKey {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct OwnerKeyVisitor;
+
+        impl<'de> Visitor<'de> for OwnerKeyVisitor {
+            type Value = OwnerKey;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                formatter.write_str(
+                    "A single owner string like '@alice' or an array like ['@alice', '@bob']",
+                )
+            }
+
+            fn visit_str<E>(self, value: &str) -> Result<OwnerKey, E>
+            where
+                E: Error,
+            {
+                let owner = Owner::from_str(value).map_err(Error::custom)?;
+                Ok(OwnerKey(vec![owner]))
+            }
+
+            fn visit_seq<A>(self, mut seq: A) -> Result<OwnerKey, A::Error>
+            where
+                A: SeqAccess<'de>,
+            {
+                let mut owners = Vec::new();
+
+                while let Some(value) = seq.next_element::<String>()? {
+                    let owner = Owner::from_str(&value).map_err(Error::custom)?;
+                    owners.push(owner);
+                }
+
+                if owners.is_empty() {
+                    return Err(Error::custom("Owner list cannot be empty"));
+                }
+
+                Ok(OwnerKey(owners))
+            }
+        }
+
+        deserializer.deserialize_any(OwnerKeyVisitor)
+    }
 }
 
 #[derive(Debug, PartialEq, Clone)]

--- a/src/teams.rs
+++ b/src/teams.rs
@@ -1,13 +1,16 @@
-use crate::structs::{CodeOwner, Owner, TeamPath};
+use crate::structs::{CodeOwner, OwnerKey, TeamPath};
 use std::collections::HashMap;
 
 /// Merges teams mapping into entries, combining owners for duplicate paths.
 /// When the same path appears in both teams and entries, owners are merged
 /// and the entry's metadata (comment/group) is preserved. Groups from teams
 /// are also applied if the entry doesn't already have a group.
+///
+/// The `teams` HashMap supports inline multi-owner keys, where a single
+/// key can contain multiple owners, e.g., ["@alice", "@bob"]: ["src/"].
 pub(crate) fn merge_teams_into_entries(
     entries: Vec<CodeOwner>,
-    teams: HashMap<Owner, Vec<TeamPath>>,
+    teams: HashMap<OwnerKey, Vec<TeamPath>>,
 ) -> Vec<CodeOwner> {
     let mut path_map: HashMap<String, CodeOwner> = HashMap::new();
 
@@ -32,13 +35,15 @@ pub(crate) fn merge_teams_into_entries(
             .or_insert(entry);
     }
 
-    for (owner, team_paths) in teams {
+    for (owner_key, team_paths) in teams {
         for team_path in team_paths {
             path_map
                 .entry(team_path.path.clone())
                 .and_modify(|existing| {
-                    if !existing.owners.contains(&owner) {
-                        existing.owners.push(owner.clone());
+                    for owner in &owner_key.0 {
+                        if !existing.owners.contains(owner) {
+                            existing.owners.push(owner.clone());
+                        }
                     }
 
                     if existing.group.is_none() && team_path.group.is_some() {
@@ -47,7 +52,7 @@ pub(crate) fn merge_teams_into_entries(
                 })
                 .or_insert_with(|| CodeOwner {
                     path: team_path.path,
-                    owners: vec![owner.clone()],
+                    owners: owner_key.0.clone(),
                     comment: None,
                     group: team_path.group,
                 });
@@ -60,6 +65,7 @@ pub(crate) fn merge_teams_into_entries(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::structs::Owner;
 
     fn path(s: &str) -> TeamPath {
         TeamPath {
@@ -75,12 +81,20 @@ mod tests {
         }
     }
 
+    fn key(owner: Owner) -> OwnerKey {
+        OwnerKey(vec![owner])
+    }
+
+    fn keys(owners: Vec<Owner>) -> OwnerKey {
+        OwnerKey(owners)
+    }
+
     #[test]
     fn test_merge_teams_creates_entries() {
         let mut teams = HashMap::new();
 
         teams.insert(
-            Owner::Username(String::from("@petergrace")),
+            key(Owner::Username(String::from("@petergrace"))),
             vec![path("src/"), path("lib/")],
         );
 
@@ -99,12 +113,12 @@ mod tests {
         let mut teams = HashMap::new();
 
         teams.insert(
-            Owner::Username(String::from("@alice")),
+            key(Owner::Username(String::from("@alice"))),
             vec![path("src/")],
         );
 
         teams.insert(
-            Owner::Team(String::from("@org/team")),
+            key(Owner::Team(String::from("@org/team"))),
             vec![path("src/")],
         );
 
@@ -127,7 +141,7 @@ mod tests {
         let mut teams = HashMap::new();
 
         teams.insert(
-            Owner::Team(String::from("@org/team")),
+            key(Owner::Team(String::from("@org/team"))),
             vec![path("src/")],
         );
 
@@ -151,7 +165,7 @@ mod tests {
         let mut teams = HashMap::new();
 
         teams.insert(
-            Owner::Username(String::from("@alice")),
+            key(Owner::Username(String::from("@alice"))),
             vec![path("src/")],
         );
 
@@ -167,7 +181,7 @@ mod tests {
         let mut teams = HashMap::new();
 
         teams.insert(
-            Owner::Username(String::from("@petergrace")),
+            key(Owner::Username(String::from("@petergrace"))),
             vec![path_with_group("src/", "core")],
         );
 
@@ -190,7 +204,7 @@ mod tests {
         let mut teams = HashMap::new();
 
         teams.insert(
-            Owner::Team(String::from("@org/team")),
+            key(Owner::Team(String::from("@org/team"))),
             vec![path_with_group("src/", "core")],
         );
 
@@ -213,7 +227,7 @@ mod tests {
         let mut teams = HashMap::new();
 
         teams.insert(
-            Owner::Team(String::from("@org/team")),
+            key(Owner::Team(String::from("@org/team"))),
             vec![path_with_group("src/", "core")],
         );
 
@@ -281,5 +295,120 @@ teams:
         let lib_entry = merged.iter().find(|e| e.path == "lib/").unwrap();
 
         assert_eq!(lib_entry.group, None);
+    }
+
+    #[test]
+    fn test_inline_multi_owner_teams() {
+        let mut teams = HashMap::new();
+
+        teams.insert(
+            keys(vec![
+                Owner::Username(String::from("@alice")),
+                Owner::Username(String::from("@bob")),
+                Owner::Team(String::from("@org/team")),
+            ]),
+            vec![path("src/"), path("lib/")],
+        );
+
+        let result = merge_teams_into_entries(vec![], teams);
+
+        assert_eq!(result.len(), 2);
+
+        for entry in &result {
+            assert_eq!(entry.owners.len(), 3);
+
+            let owner_strings: Vec<String> = entry.owners.iter().map(|o| o.to_string()).collect();
+
+            assert!(owner_strings.contains(&String::from("@alice")));
+            assert!(owner_strings.contains(&String::from("@bob")));
+            assert!(owner_strings.contains(&String::from("@org/team")));
+        }
+    }
+
+    #[test]
+    fn test_inline_multi_owner_teams_yaml_parsing() {
+        use crate::structs::CodeOwners;
+
+        const INPUT_DATA: &str = r#"
+---
+teams:
+  ["@alice", "@bob", "@org/team"]:
+    - "src/"
+    - "lib/"
+  "@carol":
+    - "docs/"
+"#;
+        let code_owners: CodeOwners = serde_yaml::from_str(INPUT_DATA).unwrap();
+
+        let merged = merge_teams_into_entries(code_owners.entries, code_owners.teams);
+
+        assert_eq!(merged.len(), 3);
+
+        let src_entry = merged.iter().find(|e| e.path == "src/").unwrap();
+
+        assert_eq!(src_entry.owners.len(), 3);
+
+        let lib_entry = merged.iter().find(|e| e.path == "lib/").unwrap();
+
+        assert_eq!(lib_entry.owners.len(), 3);
+
+        let docs_entry = merged.iter().find(|e| e.path == "docs/").unwrap();
+
+        assert_eq!(docs_entry.owners.len(), 1);
+        assert_eq!(docs_entry.owners[0].to_string(), "@carol");
+    }
+
+    #[test]
+    fn test_inline_multi_owner_deduplicates() {
+        let entries = vec![CodeOwner {
+            path: String::from("src/"),
+            owners: vec![Owner::Username(String::from("@alice"))],
+            comment: None,
+            group: None,
+        }];
+
+        let mut teams = HashMap::new();
+
+        teams.insert(
+            keys(vec![
+                Owner::Username(String::from("@alice")),
+                Owner::Username(String::from("@bob")),
+            ]),
+            vec![path("src/")],
+        );
+
+        let result = merge_teams_into_entries(entries, teams);
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].owners.len(), 2);
+    }
+
+    #[test]
+    fn test_inline_multi_owner_with_groups() {
+        use crate::structs::CodeOwners;
+
+        const INPUT_DATA: &str = r#"
+---
+teams:
+  ["@alice", "@bob"]:
+    - path: "src/"
+      group: "core"
+    - "lib/"
+"#;
+        let code_owners: CodeOwners = serde_yaml::from_str(INPUT_DATA).unwrap();
+
+        let merged = merge_teams_into_entries(code_owners.entries, code_owners.teams);
+
+        assert_eq!(merged.len(), 2);
+
+        let src_entry = merged.iter().find(|e| e.path == "src/").unwrap();
+
+        assert_eq!(src_entry.group, Some(String::from("core")));
+        assert_eq!(src_entry.owners.len(), 2);
+
+        let lib_entry = merged.iter().find(|e| e.path == "lib/").unwrap();
+
+        assert_eq!(lib_entry.group, None);
+        assert_eq!(lib_entry.owners.len(), 2);
     }
 }

--- a/src/tests/serialization.rs
+++ b/src/tests/serialization.rs
@@ -1,4 +1,4 @@
-use crate::structs::{CodeOwners, CodeOwner, Owner, TeamPath};
+use crate::structs::{CodeOwners, CodeOwner, Owner, OwnerKey, TeamPath};
 use std::collections::HashMap;
 use serde_yaml;
 
@@ -7,6 +7,10 @@ fn team_path(s: &str) -> TeamPath {
         path: s.to_string(),
         group: None,
     }
+}
+
+fn key(owner: Owner) -> OwnerKey {
+    OwnerKey(vec![owner])
 }
 
 #[test]
@@ -170,7 +174,7 @@ teams:
     let mut expected_teams = HashMap::new();
 
     expected_teams.insert(
-        Owner::Username(String::from("@petergrace")),
+        key(Owner::Username(String::from("@petergrace"))),
         vec![team_path("alpha"), team_path("zebra")]
     );
 
@@ -196,7 +200,7 @@ teams:
     let mut expected_teams = HashMap::new();
 
     expected_teams.insert(
-        Owner::Team(String::from("@myorg/team")),
+        key(Owner::Team(String::from("@myorg/team"))),
         vec![team_path("src/"), team_path("lib/")]
     );
 
@@ -221,7 +225,7 @@ teams:
     let mut expected_teams = HashMap::new();
 
     expected_teams.insert(
-        Owner::Email(String::from("pete.grace@gmail.com")),
+        key(Owner::Email(String::from("pete.grace@gmail.com"))),
         vec![team_path("docs/")]
     );
 
@@ -251,7 +255,7 @@ teams:
     let mut expected_teams = HashMap::new();
 
     expected_teams.insert(
-        Owner::Username(String::from("@petergrace")),
+        key(Owner::Username(String::from("@petergrace"))),
         vec![team_path("src/")]
     );
 
@@ -301,4 +305,97 @@ fn test_empty_config()
     };
 
     assert_eq!(value, control)
+}
+
+#[test]
+fn test_inline_multi_owner_teams()
+{
+    const INPUT_DATA: &str = r#"
+---
+teams:
+  ["@alice", "@bob", "@org/team"]:
+    - "src/"
+    - "lib/"
+"#;
+    let value = serde_yaml::from_str::<CodeOwners>(INPUT_DATA).unwrap();
+    let mut expected_teams = HashMap::new();
+
+    expected_teams.insert(
+        OwnerKey(vec![
+            Owner::Username(String::from("@alice")),
+            Owner::Username(String::from("@bob")),
+            Owner::Team(String::from("@org/team")),
+        ]),
+        vec![team_path("src/"), team_path("lib/")]
+    );
+
+    let control: CodeOwners = CodeOwners {
+        entries: vec![],
+        teams: expected_teams,
+    };
+
+    assert_eq!(value, control)
+}
+
+#[test]
+fn test_inline_multi_owner_teams_mixed_with_single()
+{
+    const INPUT_DATA: &str = r#"
+---
+teams:
+  ["@alice", "@bob"]:
+    - "src/"
+  "@carol":
+    - "docs/"
+"#;
+    let value = serde_yaml::from_str::<CodeOwners>(INPUT_DATA).unwrap();
+
+    assert_eq!(value.teams.len(), 2);
+
+    let multi_key = OwnerKey(vec![
+        Owner::Username(String::from("@alice")),
+        Owner::Username(String::from("@bob")),
+    ]);
+
+    assert!(value.teams.contains_key(&multi_key));
+
+    let single_key = key(Owner::Username(String::from("@carol")));
+
+    assert!(value.teams.contains_key(&single_key));
+}
+
+#[test]
+fn test_inline_multi_owner_empty_array_fails()
+{
+    const INPUT_DATA: &str = r#"
+---
+teams:
+  []:
+    - "src/"
+"#;
+    let result = serde_yaml::from_str::<CodeOwners>(INPUT_DATA);
+
+    assert!(result.is_err());
+
+    let err = result.unwrap_err().to_string();
+
+    assert!(err.contains("Owner list cannot be empty"), "Error was: {}", err);
+}
+
+#[test]
+fn test_inline_multi_owner_invalid_owner_fails()
+{
+    const INPUT_DATA: &str = r#"
+---
+teams:
+  ["@alice", "invalid-owner"]:
+    - "src/"
+"#;
+    let result = serde_yaml::from_str::<CodeOwners>(INPUT_DATA);
+
+    assert!(result.is_err());
+
+    let err = result.unwrap_err().to_string();
+
+    assert!(err.contains("Invalid owner format"), "Error was: {}", err);
 }


### PR DESCRIPTION
This adds support for multi-owner teams to make it more convenient to define shared ownership without much redundancy.

Example:
```yaml
---
teams:
  ["@alice", "@bob"]:
    - path: "src/"
      group: "core"
    - "lib/"
```