### PR TITLE
Introduce owner groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,53 @@ teams:
       group: "infrastructure"
 ```
 
+### Owner Groups
+
+Owner groups let you define reusable collections of owners that can be referenced by name. This is useful when the same set of owners appears in multiple places:
+
+```yaml
+---
+owner_groups:
+  - name: platform_team
+    owners:
+      - "@alice"
+      - "@bob"
+      - "@myorg/platform"
+  - name: security_team
+    owners:
+      - "@security-lead"
+      - "@myorg/security"
+```
+
+Once defined, owner groups can be referenced by their name (without `@`) in both `entries` and `teams`:
+
+```yaml
+---
+owner_groups:
+  - name: platform_team
+    owners:
+      - "@alice"
+      - "@bob"
+
+entries:
+  - path: "src/"
+    owners:
+      - "platform_team"
+      - "@extra-reviewer"
+
+teams:
+  platform_team:
+    - "lib/"
+    - "infra/"
+```
+
+In this example:
+
+- `src/` will have owners `@alice @bob @extra-reviewer`
+- `lib/` and `infra/` will each have owners `@alice @bob`
+
+**Note:** Owner groups cannot reference other owner groups (no nesting). The owners within an owner group must be valid GitHub usernames (`@user`), teams (`@org/team`), or email addresses.
+
 ### Mixed Format
 
 You can combine both formats. When the same path appears in both `teams` and `entries`, owners are merged and the entry's metadata (comment/group) is preserved:

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 #[macro_use] extern crate tracing;
 mod structs;
 mod teams;
+mod owner_groups;
 
 #[cfg(test)]
 mod tests;
@@ -54,7 +55,17 @@ fn main() -> Result<()> {
         Err(e) => bail!("Unable to parse config file: {:#?}", e)
     };
 
-    code_owners.entries = teams::merge_teams_into_entries(code_owners.entries, code_owners.teams);
+    // expand owner group references before merging
+    let (expanded_entries, expanded_teams) = match owner_groups::expand_owner_groups(
+        &code_owners.owner_groups,
+        code_owners.entries,
+        code_owners.teams,
+    ) {
+        Ok(v) => v,
+        Err(err) => bail!("Invalid owner group reference: {}", err)
+    };
+
+    code_owners.entries = teams::merge_teams_into_entries(expanded_entries, expanded_teams);
 
     let mut longest_path = 0;
     let mut grouped = false;

--- a/src/owner_groups.rs
+++ b/src/owner_groups.rs
@@ -1,0 +1,291 @@
+use crate::structs::{CodeOwner, Owner, OwnerGroup, TeamPath};
+use std::collections::HashMap;
+
+/// Expands owner group references in entries and teams to their actual owners.
+/// Returns an error if any owner group reference is not defined.
+pub(crate) fn expand_owner_groups(
+    owner_groups: &[OwnerGroup],
+    entries: Vec<CodeOwner>,
+    teams: HashMap<Owner, Vec<TeamPath>>,
+) -> Result<(Vec<CodeOwner>, HashMap<Owner, Vec<TeamPath>>), String> {
+    let group_map: HashMap<&str, &Vec<Owner>> = owner_groups
+        .iter()
+        .map(|g| (g.name.as_str(), &g.owners))
+        .collect();
+
+    let mut expanded_entries = Vec::new();
+
+    for entry in entries {
+        let expanded_owners = expand_owners(&entry.owners, &group_map)?;
+
+        expanded_entries.push(CodeOwner {
+            path: entry.path,
+            owners: expanded_owners,
+            comment: entry.comment,
+            group: entry.group,
+        });
+    }
+
+    // Expand teams
+    let mut expanded_teams: HashMap<Owner, Vec<TeamPath>> = HashMap::new();
+    for (owner, paths) in teams {
+        match &owner {
+            Owner::OwnerGroupRef(name) => {
+                let group_owners = group_map
+                    .get(name.as_str())
+                    .ok_or_else(|| format!("Unknown owner group '{}' used as team key", name))?;
+
+                for group_owner in *group_owners {
+                    expanded_teams
+                        .entry(group_owner.clone())
+                        .or_insert_with(Vec::new)
+                        .extend(paths.clone());
+                }
+            }
+            _ => {
+                expanded_teams
+                    .entry(owner)
+                    .or_insert_with(Vec::new)
+                    .extend(paths);
+            }
+        }
+    }
+
+    Ok((expanded_entries, expanded_teams))
+}
+
+fn expand_owners(
+    owners: &[Owner],
+    group_map: &HashMap<&str, &Vec<Owner>>,
+) -> Result<Vec<Owner>, String> {
+    let mut expanded = Vec::new();
+
+    for owner in owners {
+        match owner {
+            Owner::OwnerGroupRef(name) => {
+                let group_owners = group_map.get(name.as_str()).ok_or_else(|| {
+                    format!("Unknown owner group '{}' referenced in owners", name)
+                })?;
+
+                for group_owner in *group_owners {
+                    if !expanded.contains(group_owner) {
+                        expanded.push(group_owner.clone());
+                    }
+                }
+            }
+            _ => {
+                if !expanded.contains(owner) {
+                    expanded.push(owner.clone());
+                }
+            }
+        }
+    }
+
+    Ok(expanded)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_owner_group(name: &str, owners: Vec<Owner>) -> OwnerGroup {
+        OwnerGroup {
+            name: name.to_string(),
+            owners,
+        }
+    }
+
+    #[test]
+    fn test_expand_owner_group_in_entries() {
+        let owner_groups = vec![make_owner_group(
+            "my_group",
+            vec![
+                Owner::Username("@alice".to_string()),
+                Owner::Username("@bob".to_string()),
+            ],
+        )];
+
+        let entries = vec![CodeOwner {
+            path: "src/".to_string(),
+            owners: vec![Owner::OwnerGroupRef("my_group".to_string())],
+            comment: None,
+            group: None,
+        }];
+
+        let (expanded_entries, _) =
+            expand_owner_groups(&owner_groups, entries, HashMap::new()).unwrap();
+
+        assert_eq!(expanded_entries.len(), 1);
+
+        assert_eq!(expanded_entries[0].owners.len(), 2);
+
+        assert!(
+            expanded_entries[0]
+                .owners
+                .contains(&Owner::Username("@alice".to_string()))
+        );
+
+        assert!(
+            expanded_entries[0]
+                .owners
+                .contains(&Owner::Username("@bob".to_string()))
+        );
+    }
+
+    #[test]
+    fn test_expand_owner_group_as_team_key() {
+        let owner_groups = vec![make_owner_group(
+            "my_group",
+            vec![
+                Owner::Username("@alice".to_string()),
+                Owner::Team("@org/team".to_string()),
+            ],
+        )];
+
+        let mut teams = HashMap::new();
+
+        teams.insert(
+            Owner::OwnerGroupRef("my_group".to_string()),
+            vec![TeamPath {
+                path: "src/".to_string(),
+                group: None,
+            }],
+        );
+
+        let (_, expanded_teams) = expand_owner_groups(&owner_groups, vec![], teams).unwrap();
+
+        assert_eq!(expanded_teams.len(), 2);
+        assert!(expanded_teams.contains_key(&Owner::Username("@alice".to_string())));
+        assert!(expanded_teams.contains_key(&Owner::Team("@org/team".to_string())));
+    }
+
+    #[test]
+    fn test_unknown_owner_group_in_entries_fails() {
+        let owner_groups = vec![];
+
+        let entries = vec![CodeOwner {
+            path: "src/".to_string(),
+            owners: vec![Owner::OwnerGroupRef("nonexistent".to_string())],
+            comment: None,
+            group: None,
+        }];
+
+        let result = expand_owner_groups(&owner_groups, entries, HashMap::new());
+
+        assert!(result.is_err());
+
+        assert!(
+            result
+                .unwrap_err()
+                .contains("Unknown owner group 'nonexistent'")
+        );
+    }
+
+    #[test]
+    fn test_unknown_owner_group_as_team_key_fails() {
+        let owner_groups = vec![];
+
+        let mut teams = HashMap::new();
+
+        teams.insert(
+            Owner::OwnerGroupRef("nonexistent".to_string()),
+            vec![TeamPath {
+                path: "src/".to_string(),
+                group: None,
+            }],
+        );
+
+        let result = expand_owner_groups(&owner_groups, vec![], teams);
+
+        assert!(result.is_err());
+
+        assert!(
+            result
+                .unwrap_err()
+                .contains("Unknown owner group 'nonexistent'")
+        );
+    }
+
+    #[test]
+    fn test_mixed_owners_and_group_refs() {
+        let owner_groups = vec![make_owner_group(
+            "my_group",
+            vec![Owner::Username("@alice".to_string())],
+        )];
+
+        let entries = vec![CodeOwner {
+            path: "src/".to_string(),
+            owners: vec![
+                Owner::Username("@bob".to_string()),
+                Owner::OwnerGroupRef("my_group".to_string()),
+            ],
+            comment: None,
+            group: None,
+        }];
+
+        let (expanded_entries, _) =
+            expand_owner_groups(&owner_groups, entries, HashMap::new()).unwrap();
+
+        assert_eq!(expanded_entries.len(), 1);
+
+        assert_eq!(expanded_entries[0].owners.len(), 2);
+
+        assert!(
+            expanded_entries[0]
+                .owners
+                .contains(&Owner::Username("@bob".to_string()))
+        );
+
+        assert!(
+            expanded_entries[0]
+                .owners
+                .contains(&Owner::Username("@alice".to_string()))
+        );
+    }
+
+    #[test]
+    fn test_deduplicates_owners() {
+        let owner_groups = vec![make_owner_group(
+            "my_group",
+            vec![Owner::Username("@alice".to_string())],
+        )];
+
+        let entries = vec![CodeOwner {
+            path: "src/".to_string(),
+            owners: vec![
+                Owner::Username("@alice".to_string()),
+                Owner::OwnerGroupRef("my_group".to_string()),
+            ],
+            comment: None,
+            group: None,
+        }];
+
+        let (expanded_entries, _) =
+            expand_owner_groups(&owner_groups, entries, HashMap::new()).unwrap();
+
+        assert_eq!(expanded_entries.len(), 1);
+        assert_eq!(expanded_entries[0].owners.len(), 1);
+    }
+
+    #[test]
+    fn test_preserves_non_group_owners() {
+        let owner_groups = vec![];
+
+        let entries = vec![CodeOwner {
+            path: "src/".to_string(),
+            owners: vec![
+                Owner::Username("@alice".to_string()),
+                Owner::Team("@org/team".to_string()),
+                Owner::Email("test@example.com".to_string()),
+            ],
+            comment: None,
+            group: None,
+        }];
+
+        let (expanded_entries, _) =
+            expand_owner_groups(&owner_groups, entries, HashMap::new()).unwrap();
+
+        assert_eq!(expanded_entries.len(), 1);
+        assert_eq!(expanded_entries[0].owners.len(), 3);
+    }
+}

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -11,8 +11,21 @@ lazy_static! {
     static ref EMAIL: Regex = Regex::new(r"^\S+@\S+").unwrap();
 }
 
+/// Defines a group of owners that can be referenced by name
+#[derive(Deserialize, Debug, PartialEq, Clone)]
+pub(crate) struct OwnerGroup {
+    pub(crate) name: String,
+    /// Owners in this group (must be valid owners, not other group refs)
+    #[serde(deserialize_with = "strict_owners_from_string")]
+    pub(crate) owners: Vec<Owner>,
+}
+
 #[derive(Deserialize, Default, Debug, PartialEq)]
 pub(crate) struct CodeOwners {
+    /// a list of owner group definitions that can be referenced by name
+    #[serde(default)]
+    pub(crate) owner_groups: Vec<OwnerGroup>,
+
     /// a list of CodeOwner entries, that resolve to a line in CODEOWNERS file.
     #[serde(default)]
     pub(crate) entries: Vec<CodeOwner>,
@@ -103,6 +116,20 @@ fn owners_from_string<'de, D>(input: D) -> Result<Vec<Owner>, D::Error>
 where
     D: Deserializer<'de>,
 {
+    owners_from_string_internal(input, true)
+}
+
+fn strict_owners_from_string<'de, D>(input: D) -> Result<Vec<Owner>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    owners_from_string_internal(input, false)
+}
+
+fn owners_from_string_internal<'de, D>(input: D, allow_group_refs: bool) -> Result<Vec<Owner>, D::Error>
+where
+    D: Deserializer<'de>,
+{
     let mut results: Vec<Owner> = vec![];
     let input_strings: Vec<String> = Vec::deserialize(input)?;
 
@@ -114,14 +141,21 @@ where
                 results.push(Owner::Username(obj.to_string()))
             } else if EMAIL.is_match(obj) {
                 results.push(Owner::Email(obj.to_string()))
+            } else if allow_group_refs && is_valid_group_name(obj) {
+                results.push(Owner::OwnerGroupRef(obj.to_string()))
             } else {
                 return Err(Error::custom(
-                    "Invalid value for owner. Expected @username, @team/name, or email@email.com",
+                    "Invalid value for owner. Expected @username, @team/name, email@email.com, or owner_group name",
                 ));
             }
         }
     }
     Ok(results)
+}
+
+/// Check if a string is a valid owner group name (alphanumeric, underscores, hyphens)
+fn is_valid_group_name(s: &str) -> bool {
+    !s.is_empty() && s.chars().all(|c| c.is_alphanumeric() || c == '_' || c == '-')
 }
 
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
@@ -132,6 +166,8 @@ pub enum Owner {
     Team(String),
     /// Owner in the form user@domain.com
     Email(String),
+    /// Reference to an owner group by name (bare string without @)
+    OwnerGroupRef(String),
 }
 
 impl FromStr for Owner {
@@ -144,8 +180,10 @@ impl FromStr for Owner {
             Ok(Owner::Username(s.to_string()))
         } else if EMAIL.is_match(s) {
             Ok(Owner::Email(s.to_string()))
+        } else if is_valid_group_name(s) {
+            Ok(Owner::OwnerGroupRef(s.to_string()))
         } else {
-            Err("Invalid owner format. Expected @username, @org/team, or email@domain.com".into())
+            Err("Invalid owner format. Expected @username, @org/team, email@domain.com, or owner_group name".into())
         }
     }
 }
@@ -153,8 +191,7 @@ impl FromStr for Owner {
 impl std::fmt::Display for Owner {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
-            // v is a String in both cases
-            Owner::Email(v) | Owner::Team(v) | Owner::Username(v) => v.fmt(f),
+            Owner::Email(v) | Owner::Team(v) | Owner::Username(v) | Owner::OwnerGroupRef(v) => v.fmt(f),
         }
     }
 }
@@ -170,7 +207,7 @@ impl<'de> Deserialize<'de> for Owner {
             type Value = Owner;
 
             fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
-                formatter.write_str("a string like @username, @org/team, or email@domain.com")
+                formatter.write_str("a string like @username, @org/team, email@domain.com, or owner_group name")
             }
 
             fn visit_str<E>(self, value: &str) -> Result<Owner, E>

--- a/src/tests/serialization.rs
+++ b/src/tests/serialization.rs
@@ -1,4 +1,4 @@
-use crate::structs::{CodeOwners, CodeOwner, Owner, TeamPath};
+use crate::structs::{CodeOwners, CodeOwner, Owner, OwnerGroup, TeamPath};
 use std::collections::HashMap;
 use serde_yaml;
 
@@ -21,6 +21,7 @@ entries:
 ";
     let value = serde_yaml::from_str::<CodeOwners>(INPUT_DATA).unwrap();
     let control: CodeOwners = CodeOwners {
+        owner_groups: vec![],
         entries: vec![
             CodeOwner{
                 comment: None,
@@ -46,6 +47,7 @@ entries:
 ";
     let value = serde_yaml::from_str::<CodeOwners>(INPUT_DATA).unwrap();
     let control: CodeOwners = CodeOwners {
+        owner_groups: vec![],
         entries: vec![
             CodeOwner{
                 comment: None,
@@ -71,6 +73,7 @@ entries:
 ";
     let value = serde_yaml::from_str::<CodeOwners>(INPUT_DATA).unwrap();
     let control: CodeOwners = CodeOwners {
+        owner_groups: vec![],
         entries: vec![
             CodeOwner{
                 comment: None,
@@ -101,6 +104,7 @@ entries:
 ";
     let value = serde_yaml::from_str::<CodeOwners>(INPUT_DATA).unwrap();
     let control: CodeOwners = CodeOwners {
+        owner_groups: vec![],
         entries: vec![
             CodeOwner{
                 comment: None,
@@ -142,6 +146,7 @@ entries:
     let value = serde_yaml::from_str::<CodeOwners>(INPUT_DATA).unwrap();
 
     let control: CodeOwners = CodeOwners {
+        owner_groups: vec![],
         entries: vec![
             CodeOwner{
                 comment: Some(String::from("All the things")),
@@ -175,6 +180,7 @@ teams:
     );
 
     let control: CodeOwners = CodeOwners {
+        owner_groups: vec![],
         entries: vec![],
         teams: expected_teams,
     };
@@ -201,6 +207,7 @@ teams:
     );
 
     let control: CodeOwners = CodeOwners {
+        owner_groups: vec![],
         entries: vec![],
         teams: expected_teams,
     };
@@ -226,6 +233,7 @@ teams:
     );
 
     let control: CodeOwners = CodeOwners {
+        owner_groups: vec![],
         entries: vec![],
         teams: expected_teams,
     };
@@ -256,6 +264,7 @@ teams:
     );
 
     let control: CodeOwners = CodeOwners {
+        owner_groups: vec![],
         entries: vec![
             CodeOwner {
                 comment: Some(String::from("Needs metadata")),
@@ -273,10 +282,11 @@ teams:
 #[test]
 fn test_invalid_owner_in_teams()
 {
+    // Invalid owner with special characters that aren't allowed
     const INPUT_DATA: &str = "
 ---
 teams:
-  \"invalid-owner\":
+  \"invalid!owner\":
     - \"src/\"
 ";
     let result = serde_yaml::from_str::<CodeOwners>(INPUT_DATA);
@@ -289,6 +299,32 @@ teams:
 }
 
 #[test]
+fn test_owner_group_ref_in_teams_is_parsed()
+{
+    const INPUT_DATA: &str = "
+---
+teams:
+  \"my_team_group\":
+    - \"src/\"
+";
+    let value = serde_yaml::from_str::<CodeOwners>(INPUT_DATA).unwrap();
+    let mut expected_teams = HashMap::new();
+
+    expected_teams.insert(
+        Owner::OwnerGroupRef(String::from("my_team_group")),
+        vec![team_path("src/")]
+    );
+
+    let control: CodeOwners = CodeOwners {
+        owner_groups: vec![],
+        entries: vec![],
+        teams: expected_teams,
+    };
+
+    assert_eq!(value, control)
+}
+
+#[test]
 fn test_empty_config()
 {
     const INPUT_DATA: &str = "---";
@@ -296,9 +332,107 @@ fn test_empty_config()
     let value = serde_yaml::from_str::<CodeOwners>(INPUT_DATA).unwrap();
 
     let control: CodeOwners = CodeOwners {
+        owner_groups: vec![],
         entries: vec![],
         teams: HashMap::new(),
     };
 
     assert_eq!(value, control)
+}
+
+#[test]
+fn test_owner_groups_parsing()
+{
+    const INPUT_DATA: &str = "
+---
+owner_groups:
+  - name: my_group
+    owners:
+      - \"@alice\"
+      - \"@org/team\"
+entries:
+  - path: \"src/\"
+    owners:
+      - \"my_group\"
+";
+    let value = serde_yaml::from_str::<CodeOwners>(INPUT_DATA).unwrap();
+
+    let control: CodeOwners = CodeOwners {
+        owner_groups: vec![
+            OwnerGroup {
+                name: String::from("my_group"),
+                owners: vec![
+                    Owner::Username(String::from("@alice")),
+                    Owner::Team(String::from("@org/team"))
+                ]
+            }
+        ],
+        entries: vec![
+            CodeOwner {
+                comment: None,
+                group: None,
+                path: String::from("src/"),
+                owners: vec![Owner::OwnerGroupRef(String::from("my_group"))]
+            }
+        ],
+        teams: HashMap::new(),
+    };
+
+    assert_eq!(value, control)
+}
+
+#[test]
+fn test_owner_groups_with_teams()
+{
+    const INPUT_DATA: &str = "
+---
+owner_groups:
+  - name: bolt_team
+    owners:
+      - \"@bolt-ai\"
+      - \"@bolt-core\"
+teams:
+  bolt_team:
+    - \"/foo/\"
+    - \"/bar/\"
+";
+    let value = serde_yaml::from_str::<CodeOwners>(INPUT_DATA).unwrap();
+
+    let mut expected_teams = HashMap::new();
+
+    expected_teams.insert(
+        Owner::OwnerGroupRef(String::from("bolt_team")),
+        vec![team_path("/foo/"), team_path("/bar/")]
+    );
+
+    let control: CodeOwners = CodeOwners {
+        owner_groups: vec![
+            OwnerGroup {
+                name: String::from("bolt_team"),
+                owners: vec![
+                    Owner::Username(String::from("@bolt-ai")),
+                    Owner::Username(String::from("@bolt-core"))
+                ]
+            }
+        ],
+        entries: vec![],
+        teams: expected_teams,
+    };
+
+    assert_eq!(value, control)
+}
+
+#[test]
+fn test_nested_owner_group_refs_not_allowed()
+{
+    const INPUT_DATA: &str = "
+---
+owner_groups:
+  - name: group_a
+    owners:
+      - \"group_b\"
+";
+    let result = serde_yaml::from_str::<CodeOwners>(INPUT_DATA);
+
+    assert!(result.is_err());
 }


### PR DESCRIPTION
Adds support for defining owner groups, allowing for reusable collections of owners.

Example:

```yaml
---
owner_groups:
  - name: platform_team
    owners:
      - "@alice"
      - "@bob"

entries:
  - path: "src/"
    owners:
      - "platform_team"
      - "@extra-reviewer"

teams:
  platform_team:
    - "lib/"
    - "infra/"
```