### PR TITLE
Add explicit ordering for * file paths

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -83,6 +83,8 @@ fn main() -> Result<()> {
         code_owners.entries.sort_by_key(|x| x.group.clone());
     };
 
+    // Ensure filepaths are correctly ordered
+    code_owners.entries.sort();
 
     // And now, to write the file.
     let mut fd = OpenOptions::new()

--- a/src/main.rs
+++ b/src/main.rs
@@ -79,7 +79,6 @@ fn main() -> Result<()> {
             None => ()
         };
     }
-    code_owners.entries.sort_by_key(|x| x.path.clone());
     if grouped {
         code_owners.entries.sort_by_key(|x| x.group.clone());
     };

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -102,7 +102,7 @@ impl<'de> Deserialize<'de> for TeamPath {
     }
 }
 
-#[derive(Deserialize, Default, Debug, PartialEq)]
+#[derive(Deserialize, Default, Debug, PartialEq, Eq)]
 pub(crate) struct CodeOwner {
     pub(crate) path: PathBuf,
     #[serde(deserialize_with = "owners_from_string")]
@@ -111,6 +111,69 @@ pub(crate) struct CodeOwner {
     pub(crate) comment: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) group: Option<String>,
+}
+
+impl PartialOrd for CodeOwner {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+// File-path sorting
+// We need to use custom sorting to ensure * always comes before other entries.
+// Paths like /path/*.js will also correctly be ordered first, but due to ASCII ordering.
+impl Ord for CodeOwner {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        let a_str = self.path.to_str().unwrap_or("");
+        let b_str = other.path.to_str().unwrap_or("");
+        match (a_str.starts_with('*'), b_str.starts_with('*')) {
+            (true, false) => std::cmp::Ordering::Less,
+            (false, true) => std::cmp::Ordering::Greater,
+            _ => self.path.cmp(&other.path),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn entry(path: &str) -> CodeOwner {
+        CodeOwner {
+            path: PathBuf::from(path),
+            owners: vec![],
+            comment: None,
+            group: None,
+        }
+    }
+
+    #[test]
+    fn test_wildcard_sorts_before_regular_paths() {
+        let mut entries = [entry("src/"), entry("*"), entry("lib/")];
+        entries.sort();
+        assert_eq!(entries[0].path, PathBuf::from("*"));
+    }
+
+    #[test]
+    fn test_wildcard_prefix_sorts_before_regular_paths() {
+        let mut entries = [entry("src/"), entry("*.rs"), entry("lib/")];
+        entries.sort();
+        assert_eq!(entries[0].path, PathBuf::from("*.rs"));
+    }
+
+    #[test]
+    fn test_wildcard_prefix_sorts_before_regular_paths_in_dir() {
+        let mut entries = [entry("src/*.rs"), entry("src/README.md")];
+        entries.sort();
+        assert_eq!(entries[0].path, PathBuf::from("src/*.rs"));
+    }
+
+    #[test]
+    fn test_directory_sorts_before_hyphenated_path_at_same_prefix() {
+        let mut entries = [entry("path-to-a-file"), entry("path/")];
+        entries.sort();
+        assert_eq!(entries[0].path, PathBuf::from("path/"));
+    }
 }
 
 fn owners_from_string<'de, D>(input: D) -> Result<Vec<Owner>, D::Error>

--- a/src/teams.rs
+++ b/src/teams.rs
@@ -56,13 +56,17 @@ pub(crate) fn merge_teams_into_entries(
         }
     }
 
-    path_map
+    let mut entries: Vec<CodeOwner> = path_map
         .into_values()
         .map(|mut entry| {
             entry.owners.sort();
             entry
         })
-        .collect()
+        .collect();
+
+    entries.sort();
+
+    entries
 }
 
 #[cfg(test)]

--- a/src/teams.rs
+++ b/src/teams.rs
@@ -56,17 +56,13 @@ pub(crate) fn merge_teams_into_entries(
         }
     }
 
-    let mut entries: Vec<CodeOwner> = path_map
+    path_map
         .into_values()
         .map(|mut entry| {
             entry.owners.sort();
             entry
         })
-        .collect();
-
-    entries.sort();
-
-    entries
+        .collect()
 }
 
 #[cfg(test)]

--- a/src/tests/serialization.rs
+++ b/src/tests/serialization.rs
@@ -448,18 +448,23 @@ teams:
     - \"path-to-a-file\"
     - \"path/\"
     - \"another-path-to-a-file\"
-    - \"path/to-a-folder/\"
+    - \"path/to-a-nested-dir/\"
+    - \"*\"
+    - \"path/*.js\"
+    - \"path/to-a-file-in-a-dir\"
 ";
     let code_owners = serde_yaml::from_str::<CodeOwners>(INPUT_DATA).unwrap();
-    let mut entries = crate::teams::merge_teams_into_entries(code_owners.entries, code_owners.teams);
-    entries.sort_by_key(|x| x.path.clone());
+    let entries = crate::teams::merge_teams_into_entries(code_owners.entries, code_owners.teams);
 
     let paths: Vec<&str> = entries.iter().map(|e| e.path.to_str().unwrap()).collect();
 
     assert_eq!(paths, vec![
+        "*",
         "another-path-to-a-file",
         "path/",
-        "path/to-a-folder/",
+        "path/*.js",
+        "path/to-a-file-in-a-dir",
+        "path/to-a-nested-dir/",
         "path-to-a-file",
     ]);
 }

--- a/src/tests/serialization.rs
+++ b/src/tests/serialization.rs
@@ -449,13 +449,14 @@ teams:
     - \"path/\"
     - \"another-path-to-a-file\"
     - \"path/to-a-nested-dir/\"
+  \"team\":
     - \"*\"
     - \"path/*.js\"
     - \"path/to-a-file-in-a-dir\"
 ";
     let code_owners = serde_yaml::from_str::<CodeOwners>(INPUT_DATA).unwrap();
-    let entries = crate::teams::merge_teams_into_entries(code_owners.entries, code_owners.teams);
-
+    let mut entries = crate::teams::merge_teams_into_entries(code_owners.entries, code_owners.teams);
+    entries.sort();
     let paths: Vec<&str> = entries.iter().map(|e| e.path.to_str().unwrap()).collect();
 
     assert_eq!(paths, vec![


### PR DESCRIPTION
This part is actually OS specific and in some cases can place the * entry at the end instead of the beginning, which fundamentally breaks the CODEOWNERS file.

Also moved the ordering, so that it's part of the rest of the ordering code and can be tested easier.